### PR TITLE
fix: presets schema in file

### DIFF
--- a/lib/presets_data.js
+++ b/lib/presets_data.js
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import glob from 'glob'
 import runParallel from 'run-parallel'
-import { read, validate, stripLeadingUnderscores} from './utils.js'
+import { read, validate, stripLeadingUnderscores } from './utils.js'
 import { presetSchema } from '../schema/preset.js'
 
 export default function generatePresetsData (dir, opts, cb) {
@@ -13,24 +13,31 @@ export default function generatePresetsData (dir, opts, cb) {
     presetSchema.additionalProperties || (opts && opts.additionalProperties)
   glob('**/*.json', { cwd: dir }, function (err, files) {
     if (err) return cb(err)
-    if (!files.length) { console.warn('Warning: no preset json files found in', dir) }
+    if (!files.length) {
+      console.warn('Warning: no preset json files found in', dir)
+    }
     const presets = {}
-    const tasks = files.map(function (file) {
+    const tasks = files.map(function (filename) {
       return function (cb) {
-        read(path.join(dir, file), function (err, field) {
+        read(path.join(dir, filename), function (err, preset) {
           if (err) return cb(err)
-          if (!validate(file,
-            {...field,
-              schemaName: 'preset',
-              fieldIds: [],
-              addTags: field.addTags || field.tags,
-              removeTags: field.removeTags || field.addTags || field.tags,
-              terms: field.terms || []
-            }, presetSchema)) {
-            return cb(new Error(file + ': Field structure is invalid'))
+          const presetWithDefaults = {
+            fieldIds: [],
+            removeTags: {},
+            addTags: {},
+            terms: [],
+            ...preset
           }
-          const id = stripLeadingUnderscores(file.match(/([^.]*)\.json/)[1])
-          presets[id] = field
+          const isValid = validate(
+            filename,
+            { ...presetWithDefaults, schemaName: 'preset' },
+            presetSchema
+          )
+          if (!isValid) {
+            return cb(new Error(filename + ': Field structure is invalid'))
+          }
+          const id = stripLeadingUnderscores(filename.match(/([^.]*)\.json/)[1])
+          presets[id] = presetWithDefaults
           cb()
         })
       }


### PR DESCRIPTION
Ensure that the presets saved in the built config file have a valid schema (other that missing `schemaName`)